### PR TITLE
Jason/mamba integration: Basic mamba setup

### DIFF
--- a/DroneClassification/testing/mamba/01_test_mamba.ipynb
+++ b/DroneClassification/testing/mamba/01_test_mamba.ipynb
@@ -1,34 +1,25 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "source": "import sys\nimport subprocess\n\nprint(\"=\" * 60)\nprint(\"WORKING ENVIRONMENT CONFIGURATION\")\nprint(\"=\" * 60)\n\n# Python info\nprint(f\"\\nPython:\")\nprint(f\"  Version: {sys.version.split()[0]}\")\nprint(f\"  Executable: {sys.executable}\")\n\n# PyTorch info\nprint(f\"\\nPyTorch:\")\nprint(f\"  Version: {torch.__version__}\")\nprint(f\"  CUDA available: {torch.cuda.is_available()}\")\nprint(f\"  CUDA version: {torch.version.cuda}\")\nprint(f\"  cuDNN version: {torch.backends.cudnn.version()}\")\n\n# NumPy info\nimport numpy as np\nprint(f\"\\nNumPy:\")\nprint(f\"  Version: {np.__version__}\")\n\n# Mamba info\nimport mamba_ssm\nprint(f\"\\nMamba-SSM:\")\nprint(f\"  Version: {mamba_ssm.__version__ if hasattr(mamba_ssm, '__version__') else '2.2.6.post3'}\")\n\n# CUDA toolkit info (from system)\ntry:\n    nvcc_out = subprocess.check_output(['nvcc', '--version'], stderr=subprocess.STDOUT, text=True)\n    cuda_version = [line for line in nvcc_out.split('\\n') if 'release' in line.lower()][0]\n    print(f\"\\nCUDA Toolkit:\")\n    print(f\"  {cuda_version.strip()}\")\nexcept:\n    print(\"\\nCUDA Toolkit: Unable to determine\")\n\n# GPU info\nif torch.cuda.is_available():\n    print(f\"\\nGPU:\")\n    print(f\"  Device: {torch.cuda.get_device_name(0)}\")\n    print(f\"  Memory: {torch.cuda.get_device_properties(0).total_memory / 1024**3:.1f} GB\")\n\nprint(\"\\n\" + \"=\" * 60)\nprint(\"✓ All components configured correctly for Mamba training!\")\nprint(\"=\" * 60)",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "# Mamba Installation and Functionality Test (WSL2)\n\n**Purpose**: Verify that Mamba-SSM works correctly in WSL2 environment with CUDA support.\n\n**Expected Outcome**: \n- Mamba packages imported successfully\n- Basic forward pass works on CUDA\n- No errors or compatibility issues\n\n---\n\n## Environment Setup\n\nThis notebook is designed to run in **WSL2 with the `mamba-env` conda environment**.\n\n### Prerequisites (Should Already Be Completed)\n\nFollow the setup guide at `docs/WSL2_SETUP_GUIDE.md` to install:\n\n1. **WSL2** with Ubuntu\n2. **CUDA Toolkit 12.6** in WSL\n3. **Conda environment** named `mamba-env` with:\n   - Python 3.10\n   - PyTorch 2.4.1+cu121\n   - NumPy < 2.0\n   - mamba-ssm (built from source)\n\n### Running This Notebook\n\n**In VSCode with WSL Extension:**\n1. Open VSCode → Connect to WSL (green button bottom-left)\n2. Open this notebook\n3. Select kernel: **Python 3.10.19 ('mamba-env')** or **Python (Mamba-WSL2)**\n4. Run cells\n\n**Important**: Do NOT run the installation cells below if you've already followed the setup guide. Jump to Step 2 (Verify Installation).\n\n---"
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": "## Step 1: Install Mamba Packages (Optional - Only if Not Installed)\n\n**SKIP THIS STEP** if you've already followed the WSL2 setup guide.\n\nThis installs:\n- `torch==2.4.1+cu121`: PyTorch with CUDA 12.1 support\n- `numpy<2.0`: NumPy 1.x for compatibility\n- `causal-conv1d`: Required dependency (built from source)\n- `mamba-ssm`: The core Mamba library (built from source)"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": "# OPTIONAL: Only run if you haven't completed the WSL2 setup guide\n# This will take 10-15 minutes to compile from source\n\n# Install PyTorch 2.4.1 with CUDA 12.1\n!pip install torch==2.4.1 torchvision==0.19.1 torchaudio==2.4.1 --index-url https://download.pytorch.org/whl/cu121\n\n# Install NumPy 1.x\n!pip install \"numpy<2.0\"\n\n# Update C++ standard library\n!conda install -c conda-forge libstdcxx-ng -y\n\n# Build mamba-ssm from source (critical for compatibility)\n!pip cache purge\n!pip install causal-conv1d --no-binary causal-conv1d --no-build-isolation\n!pip install mamba-ssm --no-binary mamba-ssm --no-build-isolation"
+   "source": [
+    "# Basic Mamba Installation and Functionality Test (WSL2)\n",
+    "\n",
+    "## Environment Setup\n",
+    "\n",
+    "This notebook is designed to run in **WSL2 with the `mamba-env` conda environment**.\n",
+    "\n",
+    "### Prerequisites\n",
+    "\n",
+    "Follow the setup guide at `docs/WSL2_SETUP_GUIDE.md`"
+   ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Step 2: Verify Installation\n",
+    "## Verify Installation\n",
     "\n",
     "Check that packages can be imported successfully."
    ]
@@ -68,7 +59,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Step 3: Check PyTorch and CUDA Availability\n",
+    "## Check PyTorch and CUDA Availability\n",
     "\n",
     "Verify that PyTorch is installed and CUDA is available."
    ]
@@ -111,7 +102,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Step 4: Test Basic Mamba Forward Pass\n",
+    "## Test Basic Mamba Forward Pass\n",
     "\n",
     "Create a simple Mamba layer and test a forward pass with random data.\n",
     "\n",
@@ -198,10 +189,10 @@
       "✓ Output is numerically stable (no NaN/Inf)\n",
       "\n",
       "Output statistics:\n",
-      "  Mean: -0.0001\n",
-      "  Std:  0.0411\n",
-      "  Min:  -0.2012\n",
-      "  Max:  0.1837\n"
+      "  Mean: -0.0002\n",
+      "  Std:  0.0421\n",
+      "  Min:  -0.1791\n",
+      "  Max:  0.1942\n"
      ]
     }
    ],
@@ -242,25 +233,65 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Step 5: Test Gradient Flow (Training Readiness)\n",
+    "## Test Gradient Flow (Training Readiness)\n",
     "\n",
     "Verify that gradients can be computed (important for training)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
-   "source": "# Test gradient computation\ntry:\n    # Forward pass with gradients enabled\n    x_grad = torch.randn(batch_size, sequence_length, dim, requires_grad=True).to(device)\n    y_grad = model(x_grad)\n    \n    # Compute a dummy loss and backpropagate\n    loss = y_grad.mean()\n    loss.backward()\n    \n    print(\"✓ Gradient computation successful!\")\n    print(f\"  Loss value: {loss.item():.4f}\")\n    \n    # Check model parameter gradients\n    grad_params = [p for p in model.parameters() if p.grad is not None]\n    print(f\"  Parameters with gradients: {len(grad_params)}/{len(list(model.parameters()))}\")\n    \n    if len(grad_params) > 0:\n        avg_grad = torch.stack([p.grad.abs().mean() for p in grad_params]).mean()\n        print(f\"  Average gradient magnitude: {avg_grad.item():.6f}\")\n    \n    print(\"✓ Model is ready for training!\")\n    \nexcept Exception as e:\n    print(f\"✗ Gradient computation failed: {e}\")\n    import traceback\n    traceback.print_exc()"
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ Gradient computation successful!\n",
+      "  Loss value: 0.0004\n",
+      "  Parameters with gradients: 9/9\n",
+      "  Average gradient magnitude: 0.000026\n",
+      "✓ Model is ready for training!\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Test gradient computation\n",
+    "try:\n",
+    "    # Forward pass with gradients enabled\n",
+    "    x_grad = torch.randn(batch_size, sequence_length, dim, requires_grad=True).to(device)\n",
+    "    y_grad = model(x_grad)\n",
+    "    \n",
+    "    # Compute a dummy loss and backpropagate\n",
+    "    loss = y_grad.mean()\n",
+    "    loss.backward()\n",
+    "    \n",
+    "    print(\"✓ Gradient computation successful!\")\n",
+    "    print(f\"  Loss value: {loss.item():.4f}\")\n",
+    "    \n",
+    "    # Check model parameter gradients\n",
+    "    grad_params = [p for p in model.parameters() if p.grad is not None]\n",
+    "    print(f\"  Parameters with gradients: {len(grad_params)}/{len(list(model.parameters()))}\")\n",
+    "    \n",
+    "    if len(grad_params) > 0:\n",
+    "        avg_grad = torch.stack([p.grad.abs().mean() for p in grad_params]).mean()\n",
+    "        print(f\"  Average gradient magnitude: {avg_grad.item():.6f}\")\n",
+    "    \n",
+    "    print(\"✓ Model is ready for training!\")\n",
+    "    \n",
+    "except Exception as e:\n",
+    "    print(f\"✗ Gradient computation failed: {e}\")\n",
+    "    import traceback\n",
+    "    traceback.print_exc()"
+   ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Step 6: Memory Usage Test\n",
+    "## Environment Summary\n",
     "\n",
-    "Check GPU memory usage for different sequence lengths (important for understanding limitations)."
+    "Display the complete working environment configuration."
    ]
   },
   {
@@ -272,62 +303,88 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Testing memory usage with different sequence lengths...\n",
+      "============================================================\n",
+      "WORKING ENVIRONMENT CONFIGURATION\n",
+      "============================================================\n",
       "\n",
-      "Sequence length   64: Allocated:  17.45 MB, Reserved:  24.00 MB, Peak:  17.86 MB\n",
-      "Sequence length  128: Allocated:  17.51 MB, Reserved:  24.00 MB, Peak:  18.31 MB\n",
-      "Sequence length  256: Allocated:  17.64 MB, Reserved:  24.00 MB, Peak:  19.19 MB\n",
-      "Sequence length  512: Allocated:  17.89 MB, Reserved:  26.00 MB, Peak:  20.95 MB\n",
-      "Sequence length 1024: Allocated:  18.39 MB, Reserved:  28.00 MB, Peak:  24.47 MB\n"
+      "Python:\n",
+      "  Version: 3.10.19\n",
+      "  Executable: /home/jason/miniconda3/envs/mamba-env/bin/python\n",
+      "\n",
+      "PyTorch:\n",
+      "  Version: 2.4.1+cu121\n",
+      "  CUDA available: True\n",
+      "  CUDA version: 12.1\n",
+      "  cuDNN version: 90100\n",
+      "\n",
+      "NumPy:\n",
+      "  Version: 1.26.4\n",
+      "\n",
+      "Mamba-SSM:\n",
+      "  Version: 2.2.6.post3\n",
+      "\n",
+      "CUDA Toolkit:\n",
+      "  Cuda compilation tools, release 12.6, V12.6.20\n",
+      "\n",
+      "GPU:\n",
+      "  Device: NVIDIA GeForce RTX 4060\n",
+      "  Memory: 8.0 GB\n",
+      "\n",
+      "============================================================\n",
+      "✓ All components configured correctly for Mamba training!\n",
+      "============================================================\n"
      ]
     }
    ],
    "source": [
+    "import sys\n",
+    "import subprocess\n",
+    "\n",
+    "print(\"=\" * 60)\n",
+    "print(\"WORKING ENVIRONMENT CONFIGURATION\")\n",
+    "print(\"=\" * 60)\n",
+    "\n",
+    "# Python info\n",
+    "print(f\"\\nPython:\")\n",
+    "print(f\"  Version: {sys.version.split()[0]}\")\n",
+    "print(f\"  Executable: {sys.executable}\")\n",
+    "\n",
+    "# PyTorch info\n",
+    "print(f\"\\nPyTorch:\")\n",
+    "print(f\"  Version: {torch.__version__}\")\n",
+    "print(f\"  CUDA available: {torch.cuda.is_available()}\")\n",
+    "print(f\"  CUDA version: {torch.version.cuda}\")\n",
+    "print(f\"  cuDNN version: {torch.backends.cudnn.version()}\")\n",
+    "\n",
+    "# NumPy info\n",
+    "import numpy as np\n",
+    "print(f\"\\nNumPy:\")\n",
+    "print(f\"  Version: {np.__version__}\")\n",
+    "\n",
+    "# Mamba info\n",
+    "import mamba_ssm\n",
+    "print(f\"\\nMamba-SSM:\")\n",
+    "print(f\"  Version: {mamba_ssm.__version__ if hasattr(mamba_ssm, '__version__') else '2.2.6.post3'}\")\n",
+    "\n",
+    "# CUDA toolkit info (from system)\n",
+    "try:\n",
+    "    nvcc_out = subprocess.check_output(['nvcc', '--version'], stderr=subprocess.STDOUT, text=True)\n",
+    "    cuda_version = [line for line in nvcc_out.split('\\n') if 'release' in line.lower()][0]\n",
+    "    print(f\"\\nCUDA Toolkit:\")\n",
+    "    print(f\"  {cuda_version.strip()}\")\n",
+    "except:\n",
+    "    print(\"\\nCUDA Toolkit: Unable to determine\")\n",
+    "\n",
+    "# GPU info\n",
     "if torch.cuda.is_available():\n",
-    "    print(\"Testing memory usage with different sequence lengths...\\n\")\n",
-    "    \n",
-    "    sequence_lengths = [64, 128, 256, 512, 1024]\n",
-    "    \n",
-    "    for seq_len in sequence_lengths:\n",
-    "        # Clear cache\n",
-    "        torch.cuda.empty_cache()\n",
-    "        torch.cuda.reset_peak_memory_stats()\n",
-    "        \n",
-    "        try:\n",
-    "            # Create input\n",
-    "            x_test = torch.randn(1, seq_len, dim).to(device)\n",
-    "            \n",
-    "            # Forward pass\n",
-    "            with torch.no_grad():\n",
-    "                y_test = model(x_test)\n",
-    "            \n",
-    "            # Get memory stats\n",
-    "            mem_allocated = torch.cuda.memory_allocated() / 1024**2\n",
-    "            mem_reserved = torch.cuda.memory_reserved() / 1024**2\n",
-    "            mem_peak = torch.cuda.max_memory_allocated() / 1024**2\n",
-    "            \n",
-    "            print(f\"Sequence length {seq_len:4d}: \"\n",
-    "                  f\"Allocated: {mem_allocated:6.2f} MB, \"\n",
-    "                  f\"Reserved: {mem_reserved:6.2f} MB, \"\n",
-    "                  f\"Peak: {mem_peak:6.2f} MB\")\n",
-    "            \n",
-    "        except RuntimeError as e:\n",
-    "            if \"out of memory\" in str(e):\n",
-    "                print(f\"Sequence length {seq_len:4d}: ✗ Out of memory\")\n",
-    "                break\n",
-    "            else:\n",
-    "                raise\n",
-    "    \n",
-    "    # Final cleanup\n",
-    "    torch.cuda.empty_cache()\n",
-    "else:\n",
-    "    print(\"Skipping memory test (CUDA not available)\")"
+    "    print(f\"\\nGPU:\")\n",
+    "    print(f\"  Device: {torch.cuda.get_device_name(0)}\")\n",
+    "    print(f\"  Memory: {torch.cuda.get_device_properties(0).total_memory / 1024**3:.1f} GB\")\n",
+    "\n",
+    "print(\"\\n\" + \"=\" * 60)\n",
+    "print(\"✓ All components configured correctly for Mamba training!\")\n",
+    "print(\"=\" * 60)"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "source": "## Step 7: Environment Summary\n\nDisplay the complete working environment configuration.",
-   "metadata": {}
   }
  ],
  "metadata": {

--- a/DroneClassification/testing/mamba/docs/WSL2_SETUP_GUIDE.md
+++ b/DroneClassification/testing/mamba/docs/WSL2_SETUP_GUIDE.md
@@ -1,12 +1,6 @@
 # WSL2 + CUDA Setup Guide for Mamba Integration
 
-**Purpose**: Set up Linux environment on Windows for training Mamba models while keeping your existing Windows workflow intact.
-
-**Timeline**: ~1-2 hours (depending on download speeds)
-
----
-
-## Key Version Requirements (Tested & Working)
+## Key Version Requirements
 
 After extensive testing, these specific versions are required for mamba-ssm to work correctly:
 
@@ -32,7 +26,7 @@ After extensive testing, these specific versions are required for mamba-ssm to w
 
 ---
 
-## Step 1: Install WSL2 (15-30 minutes)
+## Step 1: Install WSL2
 
 ### 1.1 Enable WSL2 (PowerShell as Administrator)
 
@@ -70,7 +64,7 @@ wsl --set-version Ubuntu 2
 
 ---
 
-## Step 2: Update Ubuntu (5-10 minutes)
+## Step 2: Update Ubuntu
 
 Open Ubuntu terminal (search "Ubuntu" in Start menu):
 
@@ -84,7 +78,7 @@ sudo apt install -y build-essential wget git curl
 
 ---
 
-## Step 3: Install NVIDIA Drivers (Windows side - 10 minutes)
+## Step 3: Install NVIDIA Drivers (Windows side)
 
 **Important**: Install NVIDIA drivers on Windows, NOT in WSL2.
 
@@ -106,7 +100,7 @@ Download latest driver from: https://www.nvidia.com/Download/index.aspx
 
 ---
 
-## Step 4: Install CUDA in WSL2 (20-30 minutes)
+## Step 4: Install CUDA in WSL2
 
 **Important**: Do NOT install NVIDIA drivers in WSL2, only CUDA toolkit!
 
@@ -159,7 +153,7 @@ nvcc --version
 
 ---
 
-## Step 5: Install Miniconda (10 minutes)
+## Step 5: Install Miniconda
 
 ```bash
 # Download Miniconda
@@ -180,7 +174,7 @@ rm Miniconda3-latest-Linux-x86_64.sh
 
 ---
 
-## Step 6: Create Mamba Environment (15-20 minutes)
+## Step 6: Create Mamba Environment
 
 ### 6.1 Navigate to Your Repo
 
@@ -221,7 +215,7 @@ python -c "import torch; print(f'PyTorch: {torch.__version__}'); print(f'CUDA av
 
 ---
 
-## Step 7: Install Mamba-SSM (10-15 minutes)
+## Step 7: Install Mamba-SSM
 
 ```bash
 # Make sure you're in mamba-env
@@ -240,17 +234,13 @@ pip install causal-conv1d --no-binary causal-conv1d --no-build-isolation
 # Install mamba-ssm from source (this will compile CUDA kernels - takes 5-10 minutes!)
 pip install mamba-ssm --no-binary mamba-ssm --no-build-isolation
 
-# Verify installation
-python -c "import mamba_ssm; print('✓ Mamba-SSM installed successfully!')"
 ```
 
 **Note**: The `--no-binary` flag forces compilation from source against your specific PyTorch version. This is critical for avoiding C++ ABI compatibility issues.
 
-**If this fails**: Check troubleshooting section below.
-
 ---
 
-## Step 8: Install Project Dependencies (5 minutes)
+## Step 8: Install Project Dependencies
 
 ```bash
 # Still in /mnt/c/vscode workspace/ml-mangrove
@@ -269,34 +259,7 @@ python -m ipykernel install --user --name=mamba-env --display-name="Python (Mamb
 
 ---
 
-## Step 9: Test Everything Works (10 minutes)
-
-### 9.1 Test Mamba Installation
-
-```bash
-# Navigate to test notebook directory
-cd "/mnt/c/vscode workspace/ml-mangrove/DroneClassification/testing/mamba"
-
-# Run test notebook from command line
-jupyter nbconvert --to notebook --execute 01_test_mamba.ipynb --output 01_test_mamba_wsl2.ipynb
-```
-
-### 9.2 Or use Jupyter in browser
-
-```bash
-# Start Jupyter
-jupyter notebook --no-browser
-
-# Copy the URL with token (e.g., http://localhost:8888/?token=...)
-# Paste in your Windows browser
-# Open 01_test_mamba.ipynb
-# Select kernel: "Python (Mamba-WSL2)"
-# Run all cells
-```
-
----
-
-## Step 10: VSCode Integration (Optional - 5 minutes)
+## Step 9: VSCode Integration
 
 Connect VSCode to WSL2 for seamless development:
 
@@ -318,32 +281,11 @@ Connect VSCode to WSL2 for seamless development:
 ## Workflow After Setup
 
 ### Daily Usage:
-
-**Option A: Terminal-based**
-```bash
-# In Ubuntu terminal:
-cd "/mnt/c/vscode workspace/ml-mangrove"
-conda activate mamba-env
-
-# Run training
-jupyter nbconvert --to notebook --execute DroneClassification/testing/mamba/04_train_mamba.ipynb
-```
-
-**Option B: VSCode (recommended)**
 1. Open VSCode
 2. Click green bottom-left corner → "Reopen in WSL"
 3. Open notebook
 4. Select "Python (Mamba-WSL2)" kernel
 5. Run cells normally
-
-**Option C: Jupyter in browser**
-```bash
-# In WSL2:
-cd "/mnt/c/vscode workspace/ml-mangrove"
-conda activate mamba-env
-jupyter notebook --no-browser
-# Copy URL to Windows browser
-```
 
 ---
 
@@ -364,118 +306,6 @@ cd "/mnt/c/vscode workspace/ml-mangrove"
 ```
 
 **Recommendation**: Keep your repo on Windows (`/mnt/c/`) so both environments can easily access it.
-
----
-
-## Troubleshooting
-
-### Issue: `nvidia-smi` not working in WSL2
-
-**Solution**:
-```powershell
-# In PowerShell (Windows):
-wsl --shutdown
-# Wait 10 seconds
-# Reopen Ubuntu terminal
-```
-
-If still not working:
-- Update NVIDIA driver on Windows to 510.06+
-- Restart computer
-
----
-
-### Issue: `mamba-ssm` installation fails
-
-**Error 1**: "undefined symbol" errors (C++ ABI mismatch)
-```bash
-# This means mamba-ssm was compiled against a different PyTorch version
-# Solution: Force rebuild from source
-conda activate mamba-env
-pip cache purge
-pip uninstall -y mamba-ssm causal-conv1d
-pip install causal-conv1d --no-binary causal-conv1d --no-build-isolation
-pip install mamba-ssm --no-binary mamba-ssm --no-build-isolation
-```
-
-**Error 2**: "GLIBCXX_3.4.32 not found"
-```bash
-# Update C++ standard library
-conda activate mamba-env
-conda install -c conda-forge libstdcxx-ng -y
-```
-
-**Error 3**: NumPy version conflict
-```bash
-# Downgrade to NumPy 1.x
-pip install "numpy<2.0"
-# Then rebuild mamba-ssm (see Error 1)
-```
-
-**Error 4**: "torch.library has no attribute 'custom_op'"
-```bash
-# PyTorch version is too old (< 2.4)
-# Upgrade to PyTorch 2.4.1:
-pip uninstall -y torch torchvision torchaudio
-pip install torch==2.4.1 torchvision==0.19.1 torchaudio==2.4.1 --index-url https://download.pytorch.org/whl/cu121
-# Then rebuild mamba-ssm (see Error 1)
-```
-
-**Error 5**: Compilation errors
-```bash
-# Install build dependencies:
-sudo apt install -y build-essential ninja-build
-pip install packaging ninja
-```
-
----
-
-### Issue: Jupyter kernel not found
-
-```bash
-conda activate mamba-env
-python -m ipykernel install --user --name=mamba-env --display-name="Python (Mamba-WSL2)" --force
-
-# Restart Jupyter/VSCode
-```
-
----
-
-### Issue: Out of memory during training
-
-WSL2 uses dynamic memory allocation. To set limits:
-
-Create/edit `C:\Users\<YourUsername>\.wslconfig`:
-```ini
-[wsl2]
-memory=16GB
-processors=8
-swap=8GB
-```
-
-Then restart WSL:
-```powershell
-wsl --shutdown
-```
-
----
-
-## Performance Tips
-
-### 1. Use Windows filesystem for shared access
-- Keep code on `/mnt/c/` (Windows side)
-- Slightly slower, but accessible from both environments
-- Good for development
-
-### 2. Or use WSL filesystem for max speed
-- Clone repo to `~/ml-mangrove` (Linux side)
-- Faster I/O during training
-- Access from Windows via `\\wsl$\Ubuntu\home\<user>\ml-mangrove`
-
-### 3. Recommended split:
-- **Code/notebooks**: Windows filesystem (`/mnt/c/`)
-- **Large datasets**: WSL filesystem (`~/data/`)
-- **Model checkpoints**: Either (depends on where you need them)
 
 ---
 

--- a/DroneClassification/testing/mamba/mamba.md
+++ b/DroneClassification/testing/mamba/mamba.md
@@ -1,0 +1,42 @@
+# Mamba Integration for Mangrove Segmentation
+
+**Goal**: Integrate Mamba state-space models into the mangrove segmentation pipeline to improve performance over existing approaches, and eventually do great on satellite images.
+
+---
+
+## Quick Start
+
+### Step 1: Set Up WSL2 Environment
+
+Follow the complete setup guide to install and configure all dependencies:
+
+**Follow: [WSL2 Setup Guide](docs/WSL2_SETUP_GUIDE.md)**
+
+This will install:
+- WSL2 with Ubuntu
+- CUDA Toolkit 12.6
+- Python 3.10 environment (`mamba-env`)
+- PyTorch 2.4.1 with CUDA support
+- mamba-ssm (built from source)
+
+---
+
+### Step 2: Verify Installation
+
+After completing the setup guide, test that everything works:
+
+**Run: [01_test_mamba.ipynb](01_test_mamba.ipynb)**
+
+This notebook verifies:
+-  mamba-ssm imports successfully
+-  CUDA is accessible from PyTorch
+-  Mamba forward pass works on GPU
+-  Gradient computation works (training readiness)
+
+**How to run**:
+1. Open VSCode and connect to WSL (green button bottom-left)
+2. Open `01_test_mamba.ipynb`
+3. Select kernel: **Python (Mamba-WSL2)** or **Python 3.10.19 ('mamba-env')**
+4. Run all cells
+
+---


### PR DESCRIPTION
Basic groundwork for setting up and integrating Mamba into the pipeline. This involves 
1. Setting up WSL2 environment (since Mamba only works in Linux), and 
2. Testing out basic functionality of Mamba.

Detailed information can be found in mamba.md. 

Next: Currently working on creating components to build mamba-based vision models, and the mamba-unet model for segmentation. All separate from the existing pipeline, to make sure it works and compatible before merging. 